### PR TITLE
basic html parser

### DIFF
--- a/hScraper.cabal
+++ b/hScraper.cabal
@@ -7,8 +7,8 @@ synopsis:            A Haskell library to scrape and crawl web-pages
 -- description:         
 license:             BSD3
 license-file:        LICENSE
-author:              Nishant Gupta
-maintainer:          nishant.gupta291995@google.com
+author:              Nishant Gupta, Ayush Agarwal
+maintainer:          nishant.gupta291995@google.com, agarwal.ayush9@gmail.com
 -- copyright:           
 category:            Web
 build-type:          Simple

--- a/src/HTMLParser.hs
+++ b/src/HTMLParser.hs
@@ -1,1 +1,0 @@
---TODO : HTML Parser, for now you can work with a static html page.

--- a/src/HTMLparser.hs
+++ b/src/HTMLparser.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings, NoMonomorphismRestriction, FlexibleContexts #-}
+module HTMLparser where
+import Control.Monad (liftM, void)
+import Control.Applicative ((<*))
+
+import qualified Data.Text as T
+import Text.Parsec
+import Text.Parsec.Text
+
+
+import Types
+
+parseHtml :: T.Text -> Either ParseError HTMLTree
+parseHtml s = case parse parseNodes "" s of
+                Left err -> Left err
+                Right nodes -> Right $
+                  if length nodes == 1
+                     then head nodes
+                     else Types.toTree "html" [] nodes
+
+parseNodes = spaces >> manyTill parseNode last
+  where
+    last = eof <|> void (try (string "</"))
+
+parseNode = parseElement <|> parseText
+
+parseText = liftM (Types.toLeaf . T.pack) $ many (noneOf "<")
+
+parseElement = do
+  -- opening tag
+  (tag, attrs) <- between (char '<') (char '>') tagData
+  -- contents
+  children <- parseNodes
+  -- closing tag
+  string $ tag ++ ">" -- "</" is consumed by parseNodes, maybe bad form?
+  return $ Types.toTree (T.pack tag) attrs children
+
+tagData = do
+  t <- tagName
+  attrs <- attributes
+  return (t,attrs)
+
+tagName = many1 alphaNum
+
+attributes =  spaces >> many (traillingSpaces attribute)
+
+traillingSpaces a = a <* spaces
+
+attribute = do
+  name <- tagName
+  char '='
+  open <- char '\"' <|> char '\''
+  value <- manyTill anyChar (try $ char open)
+  return (T.pack name, T.pack value)
+

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,5 +1,6 @@
 --All types should be declared here.
 --TODO : XPath
+module Types where
 import qualified Data.Text as T
 
 data NodeType = Text T.Text
@@ -7,11 +8,18 @@ data NodeType = Text T.Text
               deriving (Show)
 
 data NTree a = NTree a [NTree a]
+             | NullTree
              deriving (Show)
 
-type AttrList = [(String , String)]
+type AttrList = [(T.Text , T.Text)]
 
 data ElementData = ElementData T.Text AttrList
                  deriving (Show)
 
 type HTMLTree = NTree NodeType
+
+toLeaf::T.Text -> HTMLTree
+toLeaf t = NTree (Text t) []
+
+toTree::T.Text -> AttrList -> [HTMLTree] -> HTMLTree
+toTree t l tree = NTree (Element (ElementData t l)) tree


### PR DESCRIPTION
doesn't take care of boundary line cases involving spaces as of now. parses the correct html